### PR TITLE
Remove extra in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,13 +22,5 @@
     "psr-4": {
       "FireGento\\FlexCms\\": ""
     }
-  },
-  "extra": {
-    "map": [
-      [
-        "*",
-        "FireGento/FlexCms"
-      ]
-    ]
   }
 }


### PR DESCRIPTION
This part of the composer.json copies the module into `app/code/`. But it is not required by Magento 2 because of the new registration.php.

So, it's works great and the module is now only in `vendor/` :)
